### PR TITLE
Add clang format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+﻿---
+BasedOnStyle: Google
+IndentWidth: '4'
+UseTab: Never
+AccessModifierOffset: -4
+
+...

--- a/lib/include/interface.h
+++ b/lib/include/interface.h
@@ -4,24 +4,21 @@
 
 #include "settings.h"
 
-class ITransaction {
-};
+class ITransaction {};
 using ITransactionPtr = std::unique_ptr<ITransaction>;
 
-enum class CommitStatus {
-    Success,
-    Error
-};
+enum class CommitStatus { Success, Error };
 
 class ISsypDB {
 public:
     virtual ITransactionPtr StartTransaction() = 0;
 
-    virtual void SetValue(std::string key, std::string value, ITransactionPtr& tx) = 0;
+    virtual void SetValue(std::string key, std::string value,
+                          ITransactionPtr& tx) = 0;
     virtual void Remove(std::string key) = 0;
 
     virtual bool GetValue(std::string key, str::string& value) = 0;
-    
+
     virtual CommitStatus Commit(ITransactionPtr tx) = 0;
 };
 

--- a/lib/src/datamodel.cpp
+++ b/lib/src/datamodel.cpp
@@ -1,7 +1,7 @@
 #include "datamodel.h"
 
-#include <string>
 #include <map>
+#include <string>
 
 class Datamodel : public IDatamodel {
 public:
@@ -24,7 +24,6 @@ public:
 private:
     std::map<std::string, std::string> storage_;
 };
-
 
 IDatamodelPtr CreateDatamodel(IStoragePtr storage, DbSettings settings) {
     return std::make_shared<Datamodel>();

--- a/lib/src/datamodel.h
+++ b/lib/src/datamodel.h
@@ -1,17 +1,14 @@
 #pragma once
-#include "storage.h"
-#include "../include/settings.h"
-
-#include <vector>
 #include <memory>
+#include <vector>
+
+#include "../include/settings.h"
+#include "storage.h"
 
 struct Op {
-    enum class Type {
-        Update,
-        Remove
-    };
+    enum class Type { Update, Remove };
     std::string key;
-    std::string value; // empty if type is Remove
+    std::string value;  // empty if type is Remove
     Type type;
 };
 

--- a/lib/src/storage.h
+++ b/lib/src/storage.h
@@ -1,8 +1,9 @@
 #pragma once
-#include "../include/settings.h"
 #include <memory>
 #include <string>
 #include <vector>
+
+#include "../include/settings.h"
 
 class ITableList {
 public:
@@ -18,7 +19,8 @@ using JournalBlob = std::vector<std::string>;
 
 class IStorage {
 public:
-    // Записывает операции в журнал. Каждый элемент вектора - отдельная операция.
+    // Записывает операции в журнал. Каждый элемент вектора - отдельная
+    // операция.
     virtual bool WriteToJournal(std::vector<std::string> ops) = 0;
 
     // Записывает новую таблицу в базу
@@ -27,7 +29,8 @@ public:
     // Возвращает view интерфейс на текущие таблицы
     virtual ITableListPtr GetTableList() = 0;
 
-    // Возвращает журнал в виде бинарных данных (может быть полезно при восстановлении базы)
+    // Возвращает журнал в виде бинарных данных (может быть полезно при
+    // восстановлении базы)
     virtual JournalBlob GetJournal() = 0;
 };
 using IStoragePtr = std::shared_ptr<IStorage>;

--- a/test/datamodel_test.cpp
+++ b/test/datamodel_test.cpp
@@ -3,7 +3,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-TEST_CASE( "Datamodel", "[set get]" ) {
+TEST_CASE("Datamodel", "[set get]") {
     auto datamodel = CreateDatamodel(nullptr, DbSettings{});
 
     Operations ops;
@@ -13,5 +13,5 @@ TEST_CASE( "Datamodel", "[set get]" ) {
     std::string value;
     datamodel->GetValue("key", value);
 
-    REQUIRE( value == "value" );
+    REQUIRE(value == "value");
 }


### PR DESCRIPTION
Добавил файл настроек для clang-format, это утилита, которая автоматически форматирует текст программы. В студии есть какой-то плагин, который будет делать это автоматически. Руками можно запускать так
```
clang-format.exe --style=file -i lib/src/datamodel.h lib/src/datamodel.cpp lib/src/storage.h
```
Думаю потом в CI настроим, что при несоблюдении code style PR проходить не будет